### PR TITLE
refactor: switch to more structured logging with slog

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -196,7 +196,7 @@ func Server(ctx *cli.Context) error {
 	// block
 	err = <-errCh
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to start server: %v", err))
+		slog.ErrorContext(context.Background(), "failed to start server", "error", err)
 		return err
 	}
 

--- a/internal/flags/domain.go
+++ b/internal/flags/domain.go
@@ -3,7 +3,6 @@ package flags
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	queryeval "github.com/nikunjy/rules/parser"
@@ -44,7 +43,7 @@ func (f *Flag) Evaluate(evalCtx map[string]any) (any, ResolutionDetails) {
 		if err != nil && errors.Is(err, ErrRuleDoesNotApply) {
 			continue
 		} else if err != nil {
-			slog.ErrorContext(context.TODO(), fmt.Sprintf("unexpected error during rule evaluation: %v", err))
+			slog.ErrorContext(context.TODO(), "unexpected error during rule evaluation", "error", err)
 			continue
 		}
 

--- a/internal/server/clients/exporter/local/exporter.go
+++ b/internal/server/clients/exporter/local/exporter.go
@@ -57,7 +57,7 @@ func NewExporter(opts ...exporter.Option) exporter.Exporter {
 	options := exporter.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate local exporter options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate local exporter options", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/exporter/mock/exporter.go
+++ b/internal/server/clients/exporter/mock/exporter.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"sync"
@@ -37,7 +36,7 @@ func NewExporter(opts ...exporter.Option) exporter.Exporter {
 	options := exporter.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate mock exporter options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate mock exporter options", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/notifier/local/notifier.go
+++ b/internal/server/clients/notifier/local/notifier.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/w-h-a/flags/internal/flags"
@@ -15,23 +14,23 @@ type client struct {
 
 func (c *client) Notify(ctx context.Context, diff flags.Diff) error {
 	for k := range diff.Deleted {
-		slog.InfoContext(ctx, fmt.Sprintf("flag %v removed", k))
+		slog.InfoContext(ctx, "flag removed", "flag", k)
 	}
 
 	for k := range diff.Added {
-		slog.InfoContext(ctx, fmt.Sprintf("flag %v added", k))
+		slog.InfoContext(ctx, "flag added", "flag", k)
 	}
 
 	for k, v := range diff.Updated {
 		if v.After.IsDisabled() != v.Before.IsDisabled() {
 			if v.After.IsDisabled() {
-				slog.InfoContext(ctx, fmt.Sprintf("flag %v is OFF", k))
+				slog.InfoContext(ctx, "flag is OFF", "flag", k)
 				continue
 			}
-			slog.InfoContext(ctx, fmt.Sprintf("flag %v is ON", k))
+			slog.InfoContext(ctx, "flag is ON", "flag", k)
 			continue
 		}
-		slog.InfoContext(ctx, fmt.Sprintf("flag %v is updated", k))
+		slog.InfoContext(ctx, "flag is updated", "flag", k)
 	}
 
 	return nil

--- a/internal/server/clients/reader/dynamodb/reader.go
+++ b/internal/server/clients/reader/dynamodb/reader.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -29,7 +28,7 @@ func init() {
 		awsconfig.WithRegion(config.Region()),
 	)
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to register dynamodb reader with otel: %v", err))
+		slog.ErrorContext(context.Background(), "failed to register dynamodb reader with otel", "error", err)
 		os.Exit(1)
 	}
 
@@ -108,7 +107,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate dynamodb reader options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate dynamodb reader options", "error", err)
 		os.Exit(1)
 	}
 
@@ -148,7 +147,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 			},
 		},
 	); err != nil && !strings.Contains(err.Error(), "ResourceInUseException") {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to create table for dynamodb reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to create table for dynamodb reader", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/reader/github/reader.go
+++ b/internal/server/clients/reader/github/reader.go
@@ -59,7 +59,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to configure github reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to configure github reader", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/reader/gitlab/reader.go
+++ b/internal/server/clients/reader/gitlab/reader.go
@@ -57,7 +57,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to configure gitlab reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to configure gitlab reader", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/reader/local/reader.go
+++ b/internal/server/clients/reader/local/reader.go
@@ -2,7 +2,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -25,7 +24,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to configure local file reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to configure local file reader", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/reader/mock/reader.go
+++ b/internal/server/clients/reader/mock/reader.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"maps"
 	"os"
@@ -58,7 +57,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate mock reader options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate mock reader options", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/reader/postgres/reader.go
+++ b/internal/server/clients/reader/postgres/reader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -25,7 +24,7 @@ func init() {
 		otelsql.WithSystem(semconv.DBSystemPostgreSQL),
 	)
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to register postgres reader with otel: %v", err))
+		slog.ErrorContext(context.Background(), "failed to register postgres reader with otel", "error", err)
 		os.Exit(1)
 	}
 
@@ -95,7 +94,7 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate postgres reader options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate postgres reader options", "error", err)
 		os.Exit(1)
 	}
 
@@ -106,42 +105,42 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	// postgres://user:password@host:port/db?sslmode=disable
 	conn, err := sql.Open(DRIVER, c.options.Location)
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to connect with postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to connect with postgres reader", "error", err)
 		os.Exit(1)
 	}
 
 	if err := conn.Ping(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to ping with postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to ping with postgres reader", "error", err)
 		os.Exit(1)
 	}
 
 	if err := otelsql.RecordStats(conn); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to initialize postgres instrumentation for postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to initialize postgres instrumentation for postgres reader", "error", err)
 		os.Exit(1)
 	}
 
 	c.conn = conn
 
 	if _, err := c.conn.Exec(`CREATE TABLE IF NOT EXISTS flags (key text NOT NULL, value bytea, CONSTRAINT flags_pkey PRIMARY KEY (key));`); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to create table for postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to create table for postgres reader", "error", err)
 		os.Exit(1)
 	}
 
 	if _, err := c.conn.Exec(`CREATE INDEX IF NOT EXISTS key_index_flags ON flags (key);`); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to create index for postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to create index for postgres reader", "error", err)
 		os.Exit(1)
 	}
 
 	readOne, err := c.conn.Prepare(`SELECT key, value FROM flags WHERE key = $1;`)
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to prepare select statement for postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to prepare select statement for postgres reader", "error", err)
 		os.Exit(1)
 	}
 	c.readOne = readOne
 
 	readMany, err := c.conn.Prepare(`SELECT key, value FROM flags;`)
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to prepare select statement for postgres reader: %v", err))
+		slog.ErrorContext(context.Background(), "failed to prepare select statement for postgres reader", "error", err)
 		os.Exit(1)
 	}
 	c.readMany = readMany

--- a/internal/server/clients/writer/dynamodb/writer.go
+++ b/internal/server/clients/writer/dynamodb/writer.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -28,7 +27,7 @@ func init() {
 		awsconfig.WithRegion(config.Region()),
 	)
 	if err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to register dynamodb writer with otel: %v", err))
+		slog.ErrorContext(context.Background(), "failed to register dynamodb writer with otel", "error", err)
 		os.Exit(1)
 	}
 
@@ -63,7 +62,7 @@ func NewWriter(opts ...writer.Option) writer.Writer {
 	options := writer.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate dynamodb writer options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate dynamodb writer options", "error", err)
 		os.Exit(1)
 	}
 
@@ -103,7 +102,7 @@ func NewWriter(opts ...writer.Option) writer.Writer {
 			},
 		},
 	); err != nil && !strings.Contains(err.Error(), "ResourceInUseException") {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to create table for dynamodb writer: %v", err))
+		slog.ErrorContext(context.Background(), "failed to create table for dynamodb writer", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/writer/noop/writer.go
+++ b/internal/server/clients/writer/noop/writer.go
@@ -2,7 +2,6 @@ package noop
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -21,7 +20,7 @@ func NewWriter(opts ...writer.Option) writer.Writer {
 	options := writer.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate noop writer: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate noop writer", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/clients/writereader/mock/writereader.go
+++ b/internal/server/clients/writereader/mock/writereader.go
@@ -68,7 +68,7 @@ func NewWriteReader(opts ...writereader.Option) writereader.WriteReader {
 	options := writereader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), fmt.Sprintf("failed to validate mock write reader options: %v", err))
+		slog.ErrorContext(context.Background(), "failed to validate mock write reader options", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -105,7 +104,7 @@ func UpdateCache(
 		case <-ticker.C:
 			old, new, err := cacheService.RetrieveFlags()
 			if err != nil {
-				slog.WarnContext(context.TODO(), fmt.Sprintf("failed to update the cache: %v", err))
+				slog.WarnContext(context.TODO(), "failed to update the cache", "error", err)
 			}
 
 			notifyService.Notify(old, new)

--- a/internal/server/services/export/service.go
+++ b/internal/server/services/export/service.go
@@ -2,7 +2,6 @@ package export
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 
@@ -50,7 +49,7 @@ func (s *Service) Flush() {
 	}
 
 	if err := s.exportClient.Export(context.TODO(), records); err != nil {
-		slog.WarnContext(context.TODO(), fmt.Sprintf("failed to export evaluation event: %v", err))
+		slog.WarnContext(context.TODO(), "failed to export evaluation event", "error", err)
 		return
 	}
 

--- a/internal/server/services/notify/service.go
+++ b/internal/server/services/notify/service.go
@@ -2,7 +2,6 @@ package notify
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 
@@ -30,7 +29,7 @@ func (s *Service) Notify(old, new map[string]*flags.Flag) {
 
 		err := s.notifyClient.Notify(context.TODO(), diff)
 		if err != nil {
-			slog.ErrorContext(context.TODO(), fmt.Sprintf("notify service failed to send message: %v", err))
+			slog.ErrorContext(context.TODO(), "notify service failed to send message", "error", err)
 		}
 	}()
 }


### PR DESCRIPTION
This PR enhances structured logging. By switching to structured logging with Go's slog package, I've aimed to improve the observability and debuggability of the system, making log data more consumable by automated tools and easier for developers to query.