### PR TITLE
refactor: make not found error a domain error not particular to any service

### DIFF
--- a/internal/flags/errors.go
+++ b/internal/flags/errors.go
@@ -1,0 +1,7 @@
+package flags
+
+import "errors"
+
+var (
+	ErrNotFound = errors.New("flag not found")
+)

--- a/internal/server/handlers/http/admin.go
+++ b/internal/server/handlers/http/admin.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/w-h-a/flags/internal/flags"
 	"github.com/w-h-a/flags/internal/server/services/admin"
 )
 
@@ -24,7 +25,7 @@ func (a *Admin) GetOne(w http.ResponseWriter, r *http.Request) {
 	}
 
 	flag, err := a.adminService.RetrieveFlag(ctx, flagKey)
-	if err != nil && errors.Is(err, admin.ErrNotFound) {
+	if err != nil && errors.Is(err, flags.ErrNotFound) {
 		writeRsp(w, http.StatusNotFound, map[string]any{"error": err.Error()})
 		return
 	} else if err != nil {
@@ -69,7 +70,7 @@ func (a *Admin) PutOne(w http.ResponseWriter, r *http.Request) {
 
 	found := true
 
-	if _, err := a.adminService.RetrieveFlag(ctx, flagKey); err != nil && errors.Is(err, admin.ErrNotFound) {
+	if _, err := a.adminService.RetrieveFlag(ctx, flagKey); err != nil && errors.Is(err, flags.ErrNotFound) {
 		found = false
 	} else if err != nil {
 		writeRsp(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
@@ -105,7 +106,7 @@ func (a *Admin) PatchOne(w http.ResponseWriter, r *http.Request) {
 	}
 
 	flag, err := a.adminService.RetrieveFlag(ctx, flagKey)
-	if err != nil && errors.Is(err, admin.ErrNotFound) {
+	if err != nil && errors.Is(err, flags.ErrNotFound) {
 		writeRsp(w, http.StatusNotFound, map[string]any{"error": err.Error()})
 		return
 	} else if err != nil {

--- a/internal/server/handlers/http/ofrep.go
+++ b/internal/server/handlers/http/ofrep.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/w-h-a/flags/internal/flags"
 	"github.com/w-h-a/flags/internal/server/config"
 	"github.com/w-h-a/flags/internal/server/services/cache"
 	"github.com/w-h-a/flags/internal/server/services/export"
@@ -32,7 +33,7 @@ func (o *OFREP) PostOne(w http.ResponseWriter, r *http.Request) {
 	}
 
 	flagState, err := o.cacheService.EvaluateFlag(ctx, flagKey, evalCtx)
-	if err != nil && errors.Is(err, cache.ErrNotFound) {
+	if err != nil && errors.Is(err, flags.ErrNotFound) {
 		writeRsp(w, http.StatusNotFound, flagState)
 		return
 	} else if err != nil {

--- a/internal/server/services/admin/service.go
+++ b/internal/server/services/admin/service.go
@@ -13,10 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	ErrNotFound = errors.New("flag not found")
-)
-
 type Service struct {
 	writeClient writer.Writer
 	readClient  reader.Reader
@@ -25,7 +21,7 @@ type Service struct {
 func (s *Service) RetrieveFlag(ctx context.Context, key string) (map[string]*flags.Flag, error) {
 	bs, err := s.readClient.ReadByKey(ctx, key)
 	if err != nil && errors.Is(err, reader.ErrRecordNotFound) {
-		return nil, ErrNotFound
+		return nil, flags.ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/internal/server/services/cache/service.go
+++ b/internal/server/services/cache/service.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"sort"
@@ -12,10 +11,6 @@ import (
 	"github.com/w-h-a/flags/internal/flags"
 	"github.com/w-h-a/flags/internal/server/clients/reader"
 	"github.com/w-h-a/flags/internal/server/config"
-)
-
-var (
-	ErrNotFound = errors.New("flag not found")
 )
 
 type Service struct {
@@ -40,7 +35,7 @@ func (s *Service) EvaluateFlag(ctx context.Context, flagKey string, evalCtx map[
 			ErrorMessage: fmt.Sprintf("flag for key '%s' does not exist", flagKey),
 		}
 
-		return result, ErrNotFound
+		return result, flags.ErrNotFound
 	}
 
 	flagValue, resolutionDetails := flag.Evaluate(evalCtx)


### PR DESCRIPTION
This pull request implements a refactoring to standardize the handling of 'not found' errors across the application. By centralizing the `ErrNotFound` definition into the flags package, the change promotes a consistent and reusable error type, improving code clarity and maintainability by making 'not found' a domain error rather than a service-specific one.

