### PR TITLE
fix: use panic instead of os.Exit(1) so log has time to flush

### DIFF
--- a/internal/server/clients/exporter/local/exporter.go
+++ b/internal/server/clients/exporter/local/exporter.go
@@ -57,8 +57,9 @@ func NewExporter(opts ...exporter.Option) exporter.Exporter {
 	options := exporter.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate local exporter options", "error", err)
-		os.Exit(1)
+		detail := "failed to validate local exporter options"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	p := &exporter.Parser{}

--- a/internal/server/clients/exporter/mock/exporter.go
+++ b/internal/server/clients/exporter/mock/exporter.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"context"
 	"log/slog"
-	"os"
 	"sync"
 
 	"github.com/w-h-a/flags/internal/server/clients/exporter"
@@ -36,8 +35,9 @@ func NewExporter(opts ...exporter.Option) exporter.Exporter {
 	options := exporter.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate mock exporter options", "error", err)
-		os.Exit(1)
+		detail := "failed to validate mock exporter options"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	p := &exporter.Parser{}

--- a/internal/server/clients/notifier/slack/notifier.go
+++ b/internal/server/clients/notifier/slack/notifier.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -146,8 +145,9 @@ func NewNotifier(opts ...notifier.Option) notifier.Notifier {
 	options := notifier.NewOptions(opts...)
 
 	if len(options.URL) == 0 {
-		slog.ErrorContext(context.Background(), "slack notifier client requires URL")
-		os.Exit(1)
+		detail := "slack notifier client requires URL"
+		slog.ErrorContext(context.Background(), detail)
+		panic(detail)
 	}
 
 	httpClient := http.DefaultClient

--- a/internal/server/clients/reader/dynamodb/reader.go
+++ b/internal/server/clients/reader/dynamodb/reader.go
@@ -3,7 +3,6 @@ package dynamodb
 import (
 	"context"
 	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -28,8 +27,9 @@ func init() {
 		awsconfig.WithRegion(config.Region()),
 	)
 	if err != nil {
-		slog.ErrorContext(context.Background(), "failed to register dynamodb reader with otel", "error", err)
-		os.Exit(1)
+		detail := "failed to register dynamodb reader with otel"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	otelaws.AppendMiddlewares(&cfg.APIOptions)
@@ -107,8 +107,9 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate dynamodb reader options", "error", err)
-		os.Exit(1)
+		detail := "failed to validate dynamodb reader options"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	c := &client{
@@ -147,8 +148,9 @@ func NewReader(opts ...reader.Option) reader.Reader {
 			},
 		},
 	); err != nil && !strings.Contains(err.Error(), "ResourceInUseException") {
-		slog.ErrorContext(context.Background(), "failed to create table for dynamodb reader", "error", err)
-		os.Exit(1)
+		detail := "failed to create table for dynamodb reader"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	return c

--- a/internal/server/clients/reader/github/reader.go
+++ b/internal/server/clients/reader/github/reader.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -59,8 +58,9 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to configure github reader", "error", err)
-		os.Exit(1)
+		detail := "failed to configure github reader"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	httpClient := http.DefaultClient

--- a/internal/server/clients/reader/gitlab/reader.go
+++ b/internal/server/clients/reader/gitlab/reader.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -57,8 +56,9 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to configure gitlab reader", "error", err)
-		os.Exit(1)
+		detail := "failed to configure gitlab reader"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	httpClient := http.DefaultClient

--- a/internal/server/clients/reader/local/reader.go
+++ b/internal/server/clients/reader/local/reader.go
@@ -24,8 +24,9 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to configure local file reader", "error", err)
-		os.Exit(1)
+		detail := "failed to configure local file reader"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	c := &client{

--- a/internal/server/clients/reader/mock/reader.go
+++ b/internal/server/clients/reader/mock/reader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"maps"
-	"os"
 	"sync"
 
 	"github.com/w-h-a/flags/internal/flags"
@@ -57,8 +56,9 @@ func NewReader(opts ...reader.Option) reader.Reader {
 	options := reader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate mock reader options", "error", err)
-		os.Exit(1)
+		detail := "failed to validate mock reader options"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	c := &Client{

--- a/internal/server/clients/writer/dynamodb/writer.go
+++ b/internal/server/clients/writer/dynamodb/writer.go
@@ -3,7 +3,6 @@ package dynamodb
 import (
 	"context"
 	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,8 +26,9 @@ func init() {
 		awsconfig.WithRegion(config.Region()),
 	)
 	if err != nil {
-		slog.ErrorContext(context.Background(), "failed to register dynamodb writer with otel", "error", err)
-		os.Exit(1)
+		detail := "failed to register dynamodb writer with otel"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	otelaws.AppendMiddlewares(&cfg.APIOptions)
@@ -62,8 +62,9 @@ func NewWriter(opts ...writer.Option) writer.Writer {
 	options := writer.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate dynamodb writer options", "error", err)
-		os.Exit(1)
+		detail := "failed to validate dynamodb writer options"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	c := &client{
@@ -102,8 +103,9 @@ func NewWriter(opts ...writer.Option) writer.Writer {
 			},
 		},
 	); err != nil && !strings.Contains(err.Error(), "ResourceInUseException") {
-		slog.ErrorContext(context.Background(), "failed to create table for dynamodb writer", "error", err)
-		os.Exit(1)
+		detail := "failed to create table for dynamodb writer"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	return c

--- a/internal/server/clients/writer/noop/writer.go
+++ b/internal/server/clients/writer/noop/writer.go
@@ -3,7 +3,6 @@ package noop
 import (
 	"context"
 	"log/slog"
-	"os"
 
 	"github.com/w-h-a/flags/internal/server/clients/writer"
 )
@@ -20,8 +19,9 @@ func NewWriter(opts ...writer.Option) writer.Writer {
 	options := writer.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate noop writer", "error", err)
-		os.Exit(1)
+		detail := "failed to validate noop writer"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	c := &client{

--- a/internal/server/clients/writereader/mock/writereader.go
+++ b/internal/server/clients/writereader/mock/writereader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"sync"
 
 	"github.com/w-h-a/flags/internal/server/clients/reader"
@@ -68,8 +67,9 @@ func NewWriteReader(opts ...writereader.Option) writereader.WriteReader {
 	options := writereader.NewOptions(opts...)
 
 	if err := options.Validate(); err != nil {
-		slog.ErrorContext(context.Background(), "failed to validate mock write reader options", "error", err)
-		os.Exit(1)
+		detail := "failed to validate mock write reader options"
+		slog.ErrorContext(context.Background(), detail, "error", err)
+		panic(detail)
 	}
 
 	c := &client{

--- a/tests/integration/dynamodb/dynamodb_test.go
+++ b/tests/integration/dynamodb/dynamodb_test.go
@@ -29,7 +29,6 @@ func TestMain(m *testing.M) {
 
 	if err := populateDynamoDB(); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 
 	// waiting for cache to populate


### PR DESCRIPTION
This pull request refactors the application's error handling strategy during critical initialization failures. By transitioning from immediate process termination via `os.Exit(1`) to using `panic`, the system gains the ability to execute deferred functions, specifically allowing the structured logger (slog) to flush its buffered logs. This ensures that vital diagnostic information is not lost when the application encounters unrecoverable errors during startup.

